### PR TITLE
Use createStatement() in execute() without parameters

### DIFF
--- a/jaydebeapi/__init__.py
+++ b/jaydebeapi/__init__.py
@@ -493,15 +493,20 @@ class Cursor(object):
     def execute(self, operation, parameters=None):
         if self._connection._closed:
             raise Error()
-        if not parameters:
-            parameters = ()
         self._close_last()
-        self._prep = self._connection.jconn.prepareStatement(operation)
-        self._set_stmt_parms(self._prep, parameters)
-        try:
-            is_rs = self._prep.execute()
-        except:
-            _handle_sql_exception()
+        if not parameters:
+            self._prep = self._connection.jconn.createStatement()
+            try:
+                is_rs = self._prep.execute(operation)
+            except:
+                _handle_sql_exception()
+        else:
+            self._prep = self._connection.jconn.prepareStatement(operation)
+            self._set_stmt_parms(self._prep, parameters)
+            try:
+                is_rs = self._prep.execute()
+            except:
+                _handle_sql_exception()
         if is_rs:
             self._rs = self._prep.getResultSet()
             self._meta = self._rs.getMetaData()


### PR DESCRIPTION
Use conn.createStatement() instead of conn.prepareStatement() when no parameters are used for execute(). This avoids unwanted effort to cope with metadata when used with Apache Drill.

A minor glitch is maybe that the code keeps using the attribute named _prep for java.sql.Statement instances.